### PR TITLE
fix two set bugs

### DIFF
--- a/ds/set/set.go
+++ b/ds/set/set.go
@@ -108,8 +108,9 @@ func (s *Set) SRem(key string, member []byte) bool {
 }
 
 // SMove Move member from the set at source to the set at destination.
+// If the source set does not exist or does not contain the specified element,no operation is performed and returns 0.
 func (s *Set) SMove(src, dst string, member []byte) bool {
-	if !s.exist(src) {
+	if !s.exist(src) || !s.record[src][string(member)] {
 		return false
 	}
 
@@ -167,7 +168,7 @@ func (s *Set) SUnion(keys ...string) (val [][]byte) {
 // SDiff Returns the members of the set resulting from the difference between the first set and all the successive sets.
 func (s *Set) SDiff(keys ...string) (val [][]byte) {
 
-	if len(keys) < 2 || !s.exist(keys[0]) {
+	if !s.exist(keys[0]) {
 		return
 	}
 

--- a/ds/set/set_test.go
+++ b/ds/set/set_test.go
@@ -157,9 +157,16 @@ func TestSet_SDiff(t *testing.T) {
 	set.SAdd("set2", []byte("a"))
 	set.SAdd("set2", []byte("f"))
 	set.SAdd("set2", []byte("g"))
-
-	members := set.SDiff(key, "set2")
-	for _, m := range members {
-		t.Log(string(m))
-	}
+	t.Run("normal situation", func(t *testing.T) {
+		members := set.SDiff(key, "set2")
+		for _, m := range members {
+			t.Log(string(m))
+		}
+	})
+	t.Run("one key", func(t *testing.T) {
+		members := set.SDiff(key)
+		for _, m := range members {
+			t.Log(string(m))
+		}
+	})
 }


### PR DESCRIPTION
1. smove 返回的值为是否移动成功，因此当member不存在dst时，move操作不应发生。
2. 当sdiff 只有一个参数key时，应返回key集合中所有成员。