### PR TITLE
fix "unmarshaled from TOML" bug

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -69,7 +69,7 @@ func newConfigFromFile(config string) (*rosedb.Config, error) {
 	}
 
 	var cfg = new(rosedb.Config)
-	err = toml.Unmarshal(data, &cfg)
+	err = toml.Unmarshal(data, cfg)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
when you run with "go run ./cmd/server/main.go -config config.toml"
you would get "load config err : only a pointer to struct or map can be unmarshaled from TOML"
it was a pointer error at cmd/server/main.go line 72