### PR TITLE
set map value change bool to struct

### DIFF
--- a/ds/set/set.go
+++ b/ds/set/set.go
@@ -9,7 +9,7 @@ type (
 	}
 
 	// Record set record to save
-	Record map[string]map[string]bool
+	Record map[string]map[string]struct{}
 )
 
 // New new a set idx
@@ -22,10 +22,10 @@ func New() *Set {
 // If key does not exist, a new set is created before adding the specified members.
 func (s *Set) SAdd(key string, member []byte) int {
 	if !s.exist(key) {
-		s.record[key] = make(map[string]bool)
+		s.record[key] = make(map[string]struct{})
 	}
 
-	s.record[key][string(member)] = true
+	s.record[key][string(member)] = struct{}{}
 
 	return len(s.record[key])
 }
@@ -55,8 +55,8 @@ func (s *Set) SIsMember(key string, member []byte) bool {
 	if !s.exist(key) {
 		return false
 	}
-
-	return s.record[key][string(member)]
+	_, ok := s.record[key][string(member)]
+	return ok
 }
 
 // SRandMember When called with just the key argument, return a random element from the set value stored at key.
@@ -99,7 +99,7 @@ func (s *Set) SRem(key string, member []byte) bool {
 		return false
 	}
 
-	if ok := s.record[key][string(member)]; ok {
+	if _, ok := s.record[key][string(member)]; ok {
 		delete(s.record[key], string(member))
 		return true
 	}
@@ -114,11 +114,11 @@ func (s *Set) SMove(src, dst string, member []byte) bool {
 	}
 
 	if !s.exist(dst) {
-		s.record[dst] = make(map[string]bool)
+		s.record[dst] = make(map[string]struct{})
 	}
 
 	delete(s.record[src], string(member))
-	s.record[dst][string(member)] = true
+	s.record[dst][string(member)] = struct{}{}
 
 	return true
 }


### PR DESCRIPTION
### 结论：改变类型大约降6%内存占用

**测试方法**
var tset *set
func test() {
	tset = set.New()
	log.Println(" ===> loop begin.")
	for i := 0; i < 32*1000*1000; i++ {
		a := "1"
		bytesBuffer := bytes.NewBuffer([]byte{})
		binary.Write(bytesBuffer, binary.BigEndian, int32(i))
		tset.SAdd(a, bytesBuffer.Bytes())
	}
	log.Println(" ===> loop end.")
}

**原bool作为value**
Showing nodes accounting for 1234.51MB, 99.80% of 1237.01MB total
Dropped 5 nodes (cum <= 6.19MB)
      flat  flat%   sum%        cum   cum%
 1025.51MB 82.90% 82.90%  1025.51MB 82.90%  github.com/roseduan/rosedb/ds/set.(*Set).SAdd (inline)
     209MB 16.90% 99.80%  1236.51MB   100%  main.test
         0     0% 99.80%  1236.51MB   100%  main.main
         0     0% 99.80%  1237.01MB   100%  runtime.main

**struct作为value**
Showing nodes accounting for 1167.51MB, 99.91% of 1168.51MB total
Dropped 1 node (cum <= 5.84MB)
      flat  flat%   sum%        cum   cum%
  957.51MB 81.94% 81.94%   957.51MB 81.94%  github.com/roseduan/rosedb/ds/set.(*Set).SAdd (inline)
     210MB 17.97% 99.91%  1168.51MB   100%  main.test
         0     0% 99.91%  1168.51MB   100%  main.main
         0     0% 99.91%  1168.51MB   100%  runtime.main