### PR TITLE
LRU Cache

### DIFF
--- a/cache/README.md
+++ b/cache/README.md
@@ -1,1 +1,3 @@
 reference: https://github.com/bluele/gcache
+
+A simple lru cache that can store element by LRU category mean the oldest element will remove when we add a need element to cache and cache has been reached the max.

--- a/cache/README.md
+++ b/cache/README.md
@@ -1,0 +1,1 @@
+reference: https://github.com/bluele/gcache

--- a/cache/lru.go
+++ b/cache/lru.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-var KeyNotFoundError = errors.New("Key not found")
+var KeyNotFoundError = errors.New("key not found")
 
 type LRUCache struct {
 	size      int

--- a/cache/lru.go
+++ b/cache/lru.go
@@ -12,8 +12,8 @@ var KeyNotFoundError = errors.New("Key not found")
 type LRUCache struct {
 	size      int
 	mu        sync.RWMutex
-	items     map[interface{}]*list.Element
-	evictList *list.List
+	items     map[interface{}]*list.Element //store data
+	evictList *list.List                    //store priority for LRU
 }
 type lruItem struct {
 	key        interface{}
@@ -21,25 +21,29 @@ type lruItem struct {
 	expiration *time.Time
 }
 
+//NewLRUCache create a LRUCache with size
 func NewLRUCache(size int) *LRUCache {
 	if !(size > 0) {
 		panic("Cache size should bigger than 0")
 	}
 	c := &LRUCache{}
 	c.Setsize(size)
-	c.init()
+	c.initLRUCache()
 	return c
 }
 
-func (c *LRUCache) init() {
+//initLRUCache init LRUCache.evictList and LRUCache.items
+func (c *LRUCache) initLRUCache() {
 	c.evictList = list.New()
 	c.items = make(map[interface{}]*list.Element, c.size+1)
 }
 
+//Setsize set size
 func (c *LRUCache) Setsize(size int) {
 	c.size = size
 }
 
+//set set key-value in cache
 func (c *LRUCache) set(key, value interface{}) interface{} {
 	var item *lruItem
 	//if exists,update the value and bring it to front
@@ -61,13 +65,14 @@ func (c *LRUCache) set(key, value interface{}) interface{} {
 	return item
 }
 
-// set a new key-value pair
+// Set use lock to set key-value
 func (c *LRUCache) Set(key, value interface{}) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.set(key, value)
 }
 
+//SetWithExpire set key-value with expire time
 func (c *LRUCache) SetWithExpire(key, value interface{}, expiration time.Duration) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -76,6 +81,8 @@ func (c *LRUCache) SetWithExpire(key, value interface{}, expiration time.Duratio
 	it.(*lruItem).expiration = &t
 }
 
+//get get value by key and update priority
+//return KeyNotFoundError when fail to find
 func (c *LRUCache) get(key interface{}) (interface{}, error) {
 	item, ok := c.items[key]
 	if ok {
@@ -89,6 +96,8 @@ func (c *LRUCache) get(key interface{}) (interface{}, error) {
 	}
 	return nil, KeyNotFoundError
 }
+
+//Get use lock to get value
 func (c *LRUCache) Get(key interface{}) (interface{}, error) {
 	// get value will change priority of element
 	// so need to use Lock() instead of RLock()
@@ -97,6 +106,7 @@ func (c *LRUCache) Get(key interface{}) (interface{}, error) {
 	return c.get(key)
 }
 
+//has find key if exists
 func (c *LRUCache) has(key interface{}) bool {
 	item, ok := c.items[key]
 	if !ok {
@@ -104,12 +114,16 @@ func (c *LRUCache) has(key interface{}) bool {
 	}
 	return !item.Value.(*lruItem).IsExpired()
 }
+
+//Has find key if exists and quicker than get because of use RLock
 func (c *LRUCache) Has(key interface{}) bool {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.has(key)
 }
 
+//remove remove key-value in cache
+//success will return true
 func (c *LRUCache) remove(key interface{}) bool {
 	if ent, ok := c.items[key]; ok {
 		c.removeElement(ent)
@@ -117,23 +131,28 @@ func (c *LRUCache) remove(key interface{}) bool {
 	}
 	return false
 }
+
+//Remove use lock to remove key-value
 func (c *LRUCache) Remove(key interface{}) bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.remove(key)
 }
 
+//Clear remove all key-value in cache
 func (c *LRUCache) Clear() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.init()
+	c.initLRUCache()
 }
 
+//evict remove the oldest key-value
 func (c *LRUCache) evict() {
 	ent := c.evictList.Back()
 	c.removeElement(ent)
 }
 
+//removeElement remove some Element
 func (c *LRUCache) removeElement(e *list.Element) {
 	c.evictList.Remove(e)
 	entry := e.Value.(*lruItem)

--- a/cache/lru.go
+++ b/cache/lru.go
@@ -1,0 +1,149 @@
+package cache
+
+import (
+	"container/list"
+	"errors"
+	"sync"
+	"time"
+)
+
+var KeyNotFoundError = errors.New("Key not found")
+
+type LRUCache struct {
+	size      int
+	mu        sync.RWMutex
+	items     map[interface{}]*list.Element
+	evictList *list.List
+}
+type lruItem struct {
+	key        interface{}
+	value      interface{}
+	expiration *time.Time
+}
+
+func NewLRUCache(size int) *LRUCache {
+	if !(size > 0) {
+		panic("Cache size should bigger than 0")
+	}
+	c := &LRUCache{}
+	c.Setsize(size)
+	c.init()
+	return c
+}
+
+func (c *LRUCache) init() {
+	c.evictList = list.New()
+	c.items = make(map[interface{}]*list.Element, c.size+1)
+}
+
+func (c *LRUCache) Setsize(size int) {
+	c.size = size
+}
+
+func (c *LRUCache) set(key, value interface{}) interface{} {
+	var item *lruItem
+	//if exists,update the value and bring it to front
+	if it, ok := c.items[key]; ok {
+		c.evictList.MoveToFront(it)
+		item = it.Value.(*lruItem)
+		item.value = value
+	} else {
+		// if exceeded size,remove the last element
+		if c.evictList.Len() >= c.size {
+			c.evict()
+		}
+		item = &lruItem{
+			key:   key,
+			value: value,
+		}
+		c.items[key] = c.evictList.PushFront(item)
+	}
+	return item
+}
+
+// set a new key-value pair
+func (c *LRUCache) Set(key, value interface{}) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.set(key, value)
+}
+
+func (c *LRUCache) SetWithExpire(key, value interface{}, expiration time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	it := c.set(key, value)
+	t := time.Now().Add(expiration)
+	it.(*lruItem).expiration = &t
+}
+
+func (c *LRUCache) get(key interface{}) (interface{}, error) {
+	item, ok := c.items[key]
+	if ok {
+		it := item.Value.(*lruItem)
+		if !it.IsExpired() {
+			c.evictList.MoveToFront(item)
+			v := it.value
+			return v, nil
+		}
+		c.removeElement(item)
+	}
+	return nil, KeyNotFoundError
+}
+func (c *LRUCache) Get(key interface{}) (interface{}, error) {
+	// get value will change priority of element
+	// so need to use Lock() instead of RLock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.get(key)
+}
+
+func (c *LRUCache) has(key interface{}) bool {
+	item, ok := c.items[key]
+	if !ok {
+		return false
+	}
+	return !item.Value.(*lruItem).IsExpired()
+}
+func (c *LRUCache) Has(key interface{}) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.has(key)
+}
+
+func (c *LRUCache) remove(key interface{}) bool {
+	if ent, ok := c.items[key]; ok {
+		c.removeElement(ent)
+		return true
+	}
+	return false
+}
+func (c *LRUCache) Remove(key interface{}) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.remove(key)
+}
+
+func (c *LRUCache) Clear() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.init()
+}
+
+func (c *LRUCache) evict() {
+	ent := c.evictList.Back()
+	c.removeElement(ent)
+}
+
+func (c *LRUCache) removeElement(e *list.Element) {
+	c.evictList.Remove(e)
+	entry := e.Value.(*lruItem)
+	delete(c.items, entry.key)
+}
+
+// IsExpired returns boolean value whether this item is expired or not.
+func (it *lruItem) IsExpired() bool {
+	if it.expiration == nil {
+		return false
+	}
+	return it.expiration.Before(time.Now())
+}

--- a/cache/lru_example_test.go
+++ b/cache/lru_example_test.go
@@ -1,0 +1,22 @@
+package cache
+
+import "fmt"
+
+func Example() {
+	lru := NewLRUCache(5)
+
+	lru.Set("a", "a")
+	lru.Set("b", "b")
+	lru.Set("c", "c")
+	lru.Set("d", "d")
+	lru.Set("e", "e")
+
+	exists := lru.Has("a")
+	fmt.Println(exists)
+
+	value, _ := lru.Get("a")
+	fmt.Println(value.(string))
+
+	ok := lru.Remove("a")
+	fmt.Println(ok)
+}

--- a/cache/lru_test.go
+++ b/cache/lru_test.go
@@ -1,0 +1,103 @@
+package cache
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestNewLRUCache(t *testing.T) {
+	lru := NewLRUCache(5)
+	assert.NotNil(t, lru)
+	assert.NotNil(t, lru.items)
+	assert.NotNil(t, lru.evictList)
+
+	go func() {
+		defer func() {
+			err := recover()
+			assert.NotNil(t, err)
+		}()
+		NewLRUCache(0)
+	}()
+}
+
+func TestLRUCache_Set(t *testing.T) {
+	var err error
+	lru := NewLRUCache(2)
+	lru.Set("a", "")
+	lru.Set("b", "")
+	lru.Set("c", "")
+	lru.Set("d", "")
+	assert.Equal(t, 2, len(lru.items))
+
+	//LRU will remove the oldest element
+	_, err = lru.Get("a")
+	assert.Equal(t, KeyNotFoundError, err)
+	_, err = lru.Get("b")
+	assert.Equal(t, KeyNotFoundError, err)
+
+	//set will update value and priority
+	lru.Set("c", "c")
+	value, err := lru.Get("c")
+	assert.NoError(t, err)
+	assert.Equal(t, "c", value.(string))
+
+	lru.Set("e", "")
+	_, err = lru.get("d")
+	assert.Equal(t, KeyNotFoundError, err)
+
+}
+
+func TestLRUCache_Get(t *testing.T) {
+	var err error
+	lru := NewLRUCache(2)
+	lru.Set("a", "a")
+	lru.Set("b", "b")
+
+	value, err := lru.Get("a")
+	assert.NoError(t, err)
+	assert.Equal(t, "a", value.(string))
+
+}
+
+func TestLRUCache_SetWithExpire(t *testing.T) {
+	var err error
+	lru := NewLRUCache(2)
+	lru.SetWithExpire("a", "a", time.Nanosecond)
+	time.Sleep(time.Nanosecond)
+
+	//get will remove expired element
+	value, err := lru.Get("a")
+	assert.Equal(t, KeyNotFoundError, err)
+	assert.Len(t, lru.items, 0)
+
+	lru.SetWithExpire("a", "a", 1000*time.Second)
+	value, err = lru.Get("a")
+	assert.NoError(t, err)
+	assert.Equal(t, "a", value.(string))
+}
+
+func TestLRUCache_Remove(t *testing.T) {
+	lru := NewLRUCache(2)
+	lru.Set("a", "a")
+	lru.Set("b", "b")
+
+	assert.False(t, lru.Remove("c"))
+	assert.True(t, lru.Remove("a"))
+	assert.Len(t, lru.items, 1)
+}
+
+func TestLRUCache_Clear(t *testing.T) {
+	lru := NewLRUCache(2)
+	lru.Set("a", "a")
+	lru.Set("b", "b")
+	lru.Clear()
+	assert.Len(t, lru.items, 0)
+}
+
+func TestLRUCache_Has(t *testing.T) {
+	lru := NewLRUCache(2)
+	lru.Set("a", "a")
+	assert.True(t, lru.Has("a"))
+	assert.False(t, lru.Has("b"))
+}


### PR DESCRIPTION
我在cache package中实现了一个LRU的cache,这个cache可以存储interface{} 类型的key-value 但是由于对整个项目不是很吃透，没有把握将他嵌入项目中去。嵌入项目的步骤：
1. 调用NewLRUCache(size)来初始化一个容量为size的全局LRUCache变量。
2. 在rosedb查询时，先使用cache.Has(key)判断数据是否存在，存在则cache.Get(key)返回值，或者直接调用cache.Get根据有无error来决定是否直接返回。（两种方法，前者在cache的命中率不高的时候速度更快，在cache命中率高时后者快。后面删除和更改操作同样有这两种选择）如果key不存在，则进行磁盘查询，并将查询结果插入cache.Set(key,value)会使用LRU策略进行淘汰。
3. 当对数据库进行更改操作时，调用cache.Set(key,value）可以更新缓存。
4. 当对数据库进行删除操作时，cache.Remove(key)来同步缓存。
同时还实现了带过期时间的缓存方式，SetWithExpire(key,value,time.Duration)

Example
```go
package cache

import "fmt"

func Example() {
	lru := NewLRUCache(5)

	lru.Set("a", "a")
	lru.Set("b", "b")
	lru.Set("c", "c")
	lru.Set("d", "d")
	lru.Set("e", "e")

	exists := lru.Has("a")
	fmt.Println(exists)

	value, _ := lru.Get("a")
	fmt.Println(value.(string))

	ok := lru.Remove("a")
	fmt.Println(ok)
}

```