### PR TITLE
About support index mode[KeyValueMemMode / KeyOnlyMemMode] -> hash data structure support.

### DIFF
--- a/db_hash_test.go
+++ b/db_hash_test.go
@@ -144,8 +144,8 @@ func TestRoseDB_HExpire(t *testing.T) {
 
 	key := []byte("hash_key")
 	res, err := db.HSet(key, []byte("a"), []byte("hash-val-1"))
-	assert.Equal(t, err, nil)
-	assert.Equal(t, res, 1)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, 1, res)
 
 	err = db.HExpire(key, 10)
 	assert.Equal(t, err, nil)

--- a/db_str.go
+++ b/db_str.go
@@ -527,19 +527,7 @@ func (db *RoseDB) getVal(key []byte) ([]byte, error) {
 	// In KeyOnlyMemMode, the value not in memory.
 	// So get the value from the db file at the offset.
 	if db.config.IdxMode == KeyOnlyMemMode {
-		df, err := db.getActiveFile(String)
-		if err != nil {
-			return nil, err
-		}
-		if idx.FileId != df.Id {
-			df = db.archFiles[String][idx.FileId]
-		}
-
-		e, err := df.Read(idx.Offset)
-		if err != nil {
-			return nil, err
-		}
-		return e.Meta.Value, nil
+		return db.readValFromDbFile(idx, String), nil
 	}
 	return nil, ErrKeyNotExist
 }

--- a/ds/hash/example_test.go
+++ b/ds/hash/example_test.go
@@ -9,14 +9,14 @@ var (
 func Example() {
 	// create a new Hash and run some functions
 	hash := New()
-	hash.HSet(hashKey, "field1", []byte("Coding"))
-	hash.HSet(hashKey, "field2", []byte("Writing"))
+	hash.HSet(getTestIndexer(hashKey, "field1", "Coding"))
+	hash.HSet(getTestIndexer(hashKey, "field2", "Writing"))
 
 	ok := hash.HExists(hashKey, "field2")
 	fmt.Println(ok)
 
 	val := hash.HGet(hashKey, "field1")
-	fmt.Println(string(val))
+	fmt.Println(val.Meta.Value)
 
 	hash.HDel(hashKey, "field1")
 

--- a/ds/hash/hash.go
+++ b/ds/hash/hash.go
@@ -21,18 +21,21 @@ func New() *Hash {
 
 // HSet Sets field in the hash stored at key to value. If key does not exist, a new key holding a hash is created.
 // If field already exists in the hash, it is overwritten.
-func (h *Hash) HSet(key string, field string, idx *index.Indexer) (res int) {
-	return h.HSetVal(key, field, idx, false)
+func (h *Hash) HSet(idx *index.Indexer) (res int) {
+	return h.HSetIndexer(idx, false)
 }
 
 // HSetNx sets field in the hash stored at key to indexer, only if field does not yet exist.
 // If key does not exist, a new key holding a hash is created. If field already exists, this operation has no effect.
 // Return if the operation successful
-func (h *Hash) HSetNx(key string, field string, idx *index.Indexer) int {
-	return h.HSetVal(key, field, idx, true)
+func (h *Hash) HSetNx(idx *index.Indexer) int {
+	return h.HSetIndexer(idx, true)
 }
 
-func (h *Hash) HSetVal(key string, field string, idx *index.Indexer, onlyNotExist bool) int {
+// HSetIndexer set indexer,
+func (h *Hash) HSetIndexer(idx *index.Indexer, onlyNotExist bool) int {
+	key := string(idx.Meta.Key)
+	field := string(idx.Meta.Extra)
 	if !h.exist(key) {
 		h.record[key] = make(map[string]*index.Indexer)
 	}

--- a/ds/hash/hash.go
+++ b/ds/hash/hash.go
@@ -19,38 +19,20 @@ func New() *Hash {
 	return &Hash{make(Record)}
 }
 
-// HSet Sets field in the hash stored at key to value. If key does not exist, a new key holding a hash is created.
-// If field already exists in the hash, it is overwritten.
+// HSet put indexer in memory.
 func (h *Hash) HSet(idx *index.Indexer) (res int) {
-	return h.HSetIndexer(idx, false)
-}
-
-// HSetNx sets field in the hash stored at key to indexer, only if field does not yet exist.
-// If key does not exist, a new key holding a hash is created. If field already exists, this operation has no effect.
-// Return if the operation successful
-func (h *Hash) HSetNx(idx *index.Indexer) int {
-	return h.HSetIndexer(idx, true)
-}
-
-// HSetIndexer set indexer,
-func (h *Hash) HSetIndexer(idx *index.Indexer, onlyNotExist bool) int {
 	key := string(idx.Meta.Key)
 	field := string(idx.Meta.Extra)
 	if !h.exist(key) {
 		h.record[key] = make(map[string]*index.Indexer)
 	}
 
-	// If key does exist, both set-cmd and setnx-cmd will set idx and return operation successful.
 	if _, exist := h.record[key][field]; !exist {
-		h.record[key][field] = idx
-		return 1
-	}
-	// if key exist, set-cmd will update val.
-	if !onlyNotExist {
-		h.record[key][field] = idx
+		res = 1
 	}
 
-	return 0
+	h.record[key][field] = idx
+	return
 }
 
 // HGet returns the value associated with field in the hash stored at key.

--- a/ds/hash/hash_test.go
+++ b/ds/hash/hash_test.go
@@ -44,41 +44,21 @@ func TestNew(t *testing.T) {
 
 func TestHash_HSet(t *testing.T) {
 	hash := InitHash()
+
+	// onlyNotExist is false, equals to HSet function.
 	r1 := hash.HSet(getTestIndexer(key, "d", "123"))
 	assert.Equal(t, r1, 1)
 	r2 := hash.HSet(getTestIndexer(key, "d", "123"))
 	assert.Equal(t, r2, 0)
 	r3 := hash.HSet(getTestIndexer(key, "e", "234"))
 	assert.Equal(t, r3, 1)
-}
-
-func TestHash_HSetNx(t *testing.T) {
-	hash := InitHash()
-	r1 := hash.HSetNx(getTestIndexer(key, "a", "new one"))
-	assert.Equal(t, r1, 0)
-	r2 := hash.HSetNx(getTestIndexer(key, "f", "d-new one"))
-	assert.Equal(t, r2, 1)
-	r3 := hash.HSetNx(getTestIndexer(key, "f", "d-new one"))
-	assert.Equal(t, r3, 0)
-}
-
-func TestHash_HSetIndexer(t *testing.T) {
-	hash := InitHash()
-
-	// onlyNotExist is false, equals to HSet function.
-	r1 := hash.HSetIndexer(getTestIndexer(key, "d", "123"), false)
-	assert.Equal(t, r1, 1)
-	r2 := hash.HSetIndexer(getTestIndexer(key, "d", "123"), false)
-	assert.Equal(t, r2, 0)
-	r3 := hash.HSetIndexer(getTestIndexer(key, "e", "234"), false)
-	assert.Equal(t, r3, 1)
 
 	// onlyNotExist is true, equals to HSetNx function.
-	r4 := hash.HSetIndexer(getTestIndexer(key, "a", "new one"), true)
+	r4 := hash.HSet(getTestIndexer(key, "a", "new one"))
 	assert.Equal(t, r4, 0)
-	r5 := hash.HSetIndexer(getTestIndexer(key, "f", "d-new one"), true)
+	r5 := hash.HSet(getTestIndexer(key, "f", "d-new one"))
 	assert.Equal(t, r5, 1)
-	r6 := hash.HSetIndexer(getTestIndexer(key, "f", "d-new one"), true)
+	r6 := hash.HSet(getTestIndexer(key, "f", "d-new one"))
 	assert.Equal(t, r6, 0)
 }
 

--- a/idx.go
+++ b/idx.go
@@ -160,7 +160,7 @@ func (db *RoseDB) buildHashIndex(idx *index.Indexer, entry *storage.Entry) {
 	key := string(entry.Meta.Key)
 	switch entry.GetMark() {
 	case HashHSet:
-		db.hashIndex.indexes.HSetIndexer(idx, false)
+		db.hashIndex.indexes.HSet(idx)
 	case HashHDel:
 		db.hashIndex.indexes.HDel(key, string(entry.Meta.Extra))
 	case HashHClear:

--- a/idx.go
+++ b/idx.go
@@ -152,7 +152,7 @@ func (db *RoseDB) buildListIndex(entry *storage.Entry) {
 }
 
 // build hash indexes.
-func (db *RoseDB) buildHashIndex(entry *storage.Entry) {
+func (db *RoseDB) buildHashIndex(idx *index.Indexer, entry *storage.Entry) {
 	if db.hashIndex == nil || entry == nil {
 		return
 	}
@@ -160,7 +160,7 @@ func (db *RoseDB) buildHashIndex(entry *storage.Entry) {
 	key := string(entry.Meta.Key)
 	switch entry.GetMark() {
 	case HashHSet:
-		db.setHashIndexer(entry, false)
+		db.hashIndex.indexes.HSetIndexer(idx, false)
 	case HashHDel:
 		db.hashIndex.indexes.HDel(key, string(entry.Meta.Extra))
 	case HashHClear:

--- a/idx.go
+++ b/idx.go
@@ -160,7 +160,7 @@ func (db *RoseDB) buildHashIndex(entry *storage.Entry) {
 	key := string(entry.Meta.Key)
 	switch entry.GetMark() {
 	case HashHSet:
-		db.hashIndex.indexes.HSet(key, string(entry.Meta.Extra), entry.Meta.Value)
+		db.setHashIndexer(entry, false)
 	case HashHDel:
 		db.hashIndex.indexes.HDel(key, string(entry.Meta.Extra))
 	case HashHClear:

--- a/index/indexer.go
+++ b/index/indexer.go
@@ -4,7 +4,7 @@ import (
 	"github.com/roseduan/rosedb/storage"
 )
 
-// Indexer the data index info, stored in skip list.
+// Indexer the data index info, a component of data types index.
 type Indexer struct {
 	Meta   *storage.Meta // metadata info.
 	FileId uint32        // the file id of storing the data.

--- a/rosedb.go
+++ b/rosedb.go
@@ -835,3 +835,21 @@ func (db *RoseDB) encode(key, value interface{}) (encKey, encVal []byte, err err
 	}
 	return
 }
+
+func (db *RoseDB) readValFromDbFile(idx *index.Indexer, dataType DataType) []byte {
+	if idx == nil {
+		return nil
+	}
+	df, err := db.getActiveFile(dataType)
+	if err != nil {
+		return nil
+	}
+	if idx.FileId != df.Id {
+		df = db.archFiles[dataType][idx.FileId]
+	}
+	e, err := df.Read(idx.Offset)
+	if err != nil {
+		return nil
+	}
+	return e.Meta.Value
+}

--- a/rosedb.go
+++ b/rosedb.go
@@ -605,7 +605,7 @@ func (db *RoseDB) saveConfig() (err error) {
 
 // build the indexes for different data structures.
 func (db *RoseDB) buildIndex(entry *storage.Entry, idx *index.Indexer, isOpen bool) (err error) {
-	if db.config.IdxMode == KeyValueMemMode && entry.GetType() == String {
+	if db.config.IdxMode == KeyValueMemMode && (entry.GetType() == String || entry.GetType() == Hash) {
 		idx.Meta.Value = entry.Meta.Value
 		idx.Meta.ValueSize = uint32(len(entry.Meta.Value))
 	}
@@ -622,7 +622,7 @@ func (db *RoseDB) buildIndex(entry *storage.Entry, idx *index.Indexer, isOpen bo
 	case storage.List:
 		db.buildListIndex(entry)
 	case storage.Hash:
-		db.buildHashIndex(entry)
+		db.buildHashIndex(idx, entry)
 	case storage.Set:
 		db.buildSetIndex(entry)
 	case storage.ZSet:

--- a/txn_api.go
+++ b/txn_api.go
@@ -308,7 +308,7 @@ func (tx *Txn) hGetVal(key, field interface{}) (val []byte, err error) {
 		return
 	}
 
-	val = tx.db.hashIndex.indexes.HGet(string(encKey), string(encField))
+	val = tx.db.HGet(encKey, encField)
 	return
 }
 


### PR DESCRIPTION
#60 
关于这个issue提到的代码修改，此次更新关于hash部分的索引支持idxMode的设计：
1. 如果是KeyValueMemMode, Value会被存储在索引部分，读取的时候直接从内存中读取，
2. 如果是KeyOnlyMemMode,  Value存储在磁盘中，内存中只有对应的fileId，offset等信息，可以通过这些信息从磁盘中读取对应的value。