### PR TITLE
修改切换ActiveFile的时机(Modify the timing of replacing activeFile)

### DIFF
--- a/rosedb_test.go
+++ b/rosedb_test.go
@@ -30,6 +30,67 @@ func ReopenDb() *RoseDB {
 	return InitDb()
 }
 
+func TestRoseDb_Save(t *testing.T) {
+	config := DefaultConfig()
+	config.DirPath = "/tmp/testRoseDB"
+	config.BlockSize = 3
+	db, err := Open(config)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	testKey := []byte("test_key1")
+	testVal := []byte("test_val1")
+	e := &storage.Entry{
+		Meta: &storage.Meta{
+			Key:       testKey,
+			Value:     testVal,
+			Extra:     nil,
+			KeySize:   uint32(len(testKey)),
+			ValueSize: uint32(len(testVal)),
+			ExtraSize: 0,
+		},
+		Timestamp: 0,
+		TxId:      0,
+	}
+	err = db.store(e)
+	//if err != nil {
+	//	t.Fatal(err.Error())
+	//}
+	testKey = []byte("test_key2")
+	testVal = []byte("test_val2")
+	e2 := &storage.Entry{
+		Meta: &storage.Meta{
+			Key:       testKey,
+			Value:     testVal,
+			Extra:     nil,
+			KeySize:   uint32(len(testKey)),
+			ValueSize: uint32(len(testVal)),
+			ExtraSize: 0,
+		},
+		Timestamp: 0,
+		TxId:      0,
+	}
+	err = db.store(e2)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	testKey = []byte("test_key3")
+	testVal = []byte("test_val3")
+	e3 := &storage.Entry{
+		Meta: &storage.Meta{
+			Key:       testKey,
+			Value:     testVal,
+			Extra:     nil,
+			KeySize:   uint32(len(testKey)),
+			ValueSize: uint32(len(testVal)),
+			ExtraSize: 0,
+		},
+		Timestamp: 0,
+		TxId:      0,
+	}
+	err = db.store(e3)
+}
+
 func TestOpen(t *testing.T) {
 
 	opendb := func(method storage.FileRWMethod) {

--- a/storage/db_file.go
+++ b/storage/db_file.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"hash/crc32"
@@ -145,6 +146,56 @@ func (df *DBFile) Read(offset int64) (e *Entry, err error) {
 	}
 
 	return
+}
+
+func (df *DBFile) ReadAll() (map[int64]*Entry, error) {
+
+	bf := bytes.Buffer{}
+	if _, err := bf.ReadFrom(df.File); err != nil {
+		return nil, err
+	}
+
+	byt := bf.Bytes()
+
+	entryOffset := int64(0)
+	totalLen := int64(len(byt))
+	entries := make(map[int64]*Entry)
+	for entryOffset < totalLen {
+		endPos := entryHeaderSize
+
+		e, err := Decode(byt[:endPos])
+		if err != nil {
+			return nil, err
+		}
+		byt = byt[endPos:]
+
+		if e.Meta.KeySize > 0 {
+			endPos = int(e.Meta.KeySize)
+			e.Meta.Key = byt[:endPos]
+			byt = byt[endPos:]
+		}
+
+		if e.Meta.ValueSize > 0 {
+			endPos = int(e.Meta.ValueSize)
+			e.Meta.Value = byt[:endPos]
+			byt = byt[endPos:]
+		}
+
+		if e.Meta.ExtraSize > 0 {
+			endPos = int(e.Meta.ExtraSize)
+			e.Meta.Extra = byt[:endPos]
+			byt = byt[endPos:]
+		}
+
+		checkCrc := crc32.ChecksumIEEE(e.Meta.Value)
+		if checkCrc != e.crc32 {
+			return nil, ErrInvalidCrc
+		}
+
+		entries[entryOffset] = e
+		entryOffset += int64(e.Size())
+	}
+	return entries, nil
 }
 
 func (df *DBFile) readBuf(offset int64, n int64) ([]byte, error) {

--- a/storage/db_file_test.go
+++ b/storage/db_file_test.go
@@ -188,3 +188,18 @@ func TestDBFile_Read(t *testing.T) {
 	readEntry(0)
 	readEntry(44)
 }
+
+
+func TestDBFile_ReadAll(t *testing.T) {
+	archFiles, _, err :=  Build("/tmp/rosedb_server", FileIO, 16 * 1024 * 1024)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	entries, err := archFiles[0][0].ReadAll()
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	if len(entries) != 3 {
+		t.Fatal("want 3 entries, got ", len(entries))
+	}
+}


### PR DESCRIPTION
# 修改更换ActiveFile时机(Modify the timing of replacing ActivaFile)
## 当前实现(Now Impl)
* 判断当前entry是否能够写入ActiveFile(Determine whether the current entry can be written to ActiveFile)
* 如果不能则更换ActiveFile(If not, change ActiveFile)
* 将Entry写入到新的ActiveFile中(Write Entry to new ActiveFile)
## 修改(Modify)
* 对于当前entry, 如果ActiveFile空间不足，将超出BlockSize限制将entry写入到当前ActiveFile中(For the current entry, if the ActiveFile space is insufficient, the entry will be written to the current ActiveFile beyond the BlockSize limit)
* 采用类似懒加载方式。每次写时先检查上次写完之后ActiveFile文件是否已满, 如果满那么写之前更换ActiveFile。(Just like lazy loading, each time you write, first check whether the ActiveFile file is full after the last write is completed, if it is full, then replace the ActiveFile before writing)

## 好处(Advantage)
参照MySQL binlog处理方式，能够最大化利用空间(Imitate MySQL binlog processing method, can maximize the use of space)