### PR TITLE
persist str expire key

### DIFF
--- a/db_str.go
+++ b/db_str.go
@@ -353,6 +353,10 @@ func (db *RoseDB) setVal(key, value []byte) (err error) {
 		}
 
 		if bytes.Compare(existVal, value) == 0 {
+			// clear expire time.
+			if _, ok := db.expires[String][string(key)]; ok {
+				delete(db.expires[String], string(key))
+			}
 			return
 		}
 	}


### PR DESCRIPTION
Delete the expiration info when the new value of the string is equal to the old value. 
That's consistent with Redis and more friendly.